### PR TITLE
Copy paste error

### DIFF
--- a/Spring Core Certification Notes 4.2.md
+++ b/Spring Core Certification Notes 4.2.md
@@ -696,7 +696,7 @@ public class MyAspect {
 
 #### After returning
 - Executes after successful target method invocation
-- If advice throws an exception, target is not called
+- If target throws an exception, advice is not called
 - Return value of target method can be injected to the annotated method using `returning` param
 - @AfterReturning(value="expression", returning="paramName")
 ```java


### PR DESCRIPTION
I presume you copied this sentence from the previous section (@Before advice type). To be sure I just tested this: the target is called before executing the @AfterReturning advice even when the @AfterReturning advise throws an exception.
Maybe you can leave out this sentence completely because the first list item states the same: "Executes after successful target method invocation"